### PR TITLE
corrected spelling mistakes and updated to use nix 24.05

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   nixos-anywhere: 
-    image: nixpkgs/nix:nixos-23.11
+    image: nixpkgs/nix:nixos-24.05
     stdin_open: true
     tty: true
 # network_mode:host is not always required but if the VM is on the same machine as the docker engine, it can reduce likelihood of networking issues across internal bridges

--- a/docker/start-docker-container.sh
+++ b/docker/start-docker-container.sh
@@ -1,3 +1,3 @@
-#! /usr/bim/env bash
+#! /usr/bin/env bash
 
 docker-compose run --rm nixos-anywhere

--- a/nixos-anywhere/configuration.nix
+++ b/nixos-anywhere/configuration.nix
@@ -90,5 +90,5 @@
 
   };
 
-  system.stateVersion = "23.11";
+  system.stateVersion = "24.05";
 }

--- a/nixos-anywhere/flake.nix
+++ b/nixos-anywhere/flake.nix
@@ -1,11 +1,11 @@
 {
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-  inputs.disko.url = "github:nix-community/disko";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+  inputs.disko.url = "github:nix-community/disko/latest";
   inputs.disko.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs = { nixpkgs, disko, ... }:
     {
-      nixosConfigurations.nixos-anywhere-vm = nixpkgs.lib.nixosSystem {
+      nixosConfigurations.nixos-os-anywhere-vm = nixpkgs.lib.nixosSystem {
         system = "x86_64-linux";
         modules = [
           disko.nixosModules.disko


### PR DESCRIPTION
I added a few corrections to the project, there was a spelling mistake in start-docker-container.sh.
I also edited the files to use nix24.05.
